### PR TITLE
fix: added name getter to migration template and min/max to up Update Response Probability logic

### DIFF
--- a/firebot-script/bin/generate-migration.js
+++ b/firebot-script/bin/generate-migration.js
@@ -21,6 +21,10 @@ const dateFnsTz = require('date-fns-tz');
   const migrationTemplate = `import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class ${className}${timestamp} implements MigrationInterface {
+  get name() {
+    return '${className}${timestamp}';
+  }
+
   async up(queryRunner: QueryRunner): Promise<void> {}
 
   async down(queryRunner: QueryRunner): Promise<void> {}

--- a/firebot-script/src/custom-effect.ts
+++ b/firebot-script/src/custom-effect.ts
@@ -174,7 +174,10 @@ export function registerFirebuttUpdateResponseProbablityEffectType(
             : Number(value);
         await firebutt.updateParameters(
           {
-            responseProbability: newResponseProbability,
+            responseProbability: Math.min(
+              Math.max(newResponseProbability, 0),
+              100
+            ),
           },
           true
         );


### PR DESCRIPTION
- Added `name` getter to the migration script template as it's required to prevent an exception when running migrations as a webpacked custom script in Firebot
- Fixed bug with Update Response Probability logic that allowed values outside the expected range of 0-100