### PR TITLE
fix: using local parameter cache and fixing usage stats repo

### DIFF
--- a/firebot-script/src/chat-client.ts
+++ b/firebot-script/src/chat-client.ts
@@ -12,7 +12,7 @@ import { addUsageStatistic } from './usage-statistic';
 let chatClient: ChatClient;
 
 export function register(
-  _: Firebutt,
+  firebutt: Firebutt,
   { firebot, modules, parameters }: Omit<RunRequest<Params>, 'trigger'>,
   postProcessor: (
     runRequest: Omit<RunRequest<Params>, 'trigger'>,
@@ -29,6 +29,7 @@ export function register(
   chatClient.onMessage(
     async (_, user, messageText, chatMessage) =>
       await execute(
+        firebutt,
         { firebot, modules, parameters },
         user,
         messageText,
@@ -45,6 +46,7 @@ export function register(
 }
 
 async function execute(
+  firebutt: Firebutt,
   runRequest: Omit<RunRequest<Params>, 'trigger'>,
   user: string,
   messageText: string,
@@ -58,12 +60,11 @@ async function execute(
     firebot: {
       accounts: { bot, streamer },
     },
-    parameters,
     modules: { twitchApi, userDb: UserDb, utils: Utils },
   } = runRequest;
 
   const { ignoreRoles, ignoreUsernames, responder, responseProbability } =
-    parameters as Params;
+    firebutt.getParameters() as Params;
 
   const ignoreRolesArray = ignoreRoles.split(',').map((role) => role.trim());
   const ignoreUsernamesArray = ignoreUsernames

--- a/firebot-script/src/firebutt.ts
+++ b/firebot-script/src/firebutt.ts
@@ -27,6 +27,7 @@ import {
   register as registerPhraseManager,
   unregister as unregisterPhraseManager,
 } from './phrase-manager';
+import { register as registerUsageStatistic } from './usage-statistic';
 import { getFirebotProfileDataFolderPath } from './utils/file-system';
 import { register as registerWebInterface } from './web-interface';
 
@@ -102,6 +103,11 @@ export class Firebutt {
         parameters: this._parameters,
       });
       await registerPhraseManager(this, {
+        firebot: this._firebot,
+        modules: this._modules,
+        parameters: this._parameters,
+      });
+      await registerUsageStatistic(this, {
         firebot: this._firebot,
         modules: this._modules,
         parameters: this._parameters,
@@ -186,12 +192,12 @@ export class Firebutt {
     }
   }
 
-  updateParameters(params: Partial<Params>, saveDb: boolean = false) {
+  async updateParameters(params: Partial<Params>, saveDb: boolean = false) {
     this._parameters = { ...this._parameters, ...params };
 
     if (saveDb) {
       for (const [key, value] of Object.entries(this._parameters)) {
-        this._startupScriptConfigDb.push(
+        await this._startupScriptConfigDb.push(
           `/${this._scriptId}/parameters/${key}/value`,
           value
         );

--- a/firebot-script/src/usage-statistic.ts
+++ b/firebot-script/src/usage-statistic.ts
@@ -28,7 +28,7 @@ export async function addUsageStatistic({
   responseProbability: number;
 }): Promise<UsageStatistic> {
   const { id, guid } = newGuid({ type: 'usage-statistic' });
-  const usageStatistic = usageStatisticRepository.merge(new UsageStatistic(), {
+  const usageStatistic = usageStatisticRepository.create({
     id,
     guid,
     originalPhrase,


### PR DESCRIPTION
- Fixed a bug where `parameters` was using cached values from Firebot script execution
- Fixed bug where `UsageStatistics` repo wasn't initialized prior to use.