### PR TITLE
bug: `expires_at` gets set to invalid value when the form submits and empty string

### DIFF
--- a/web-app/src/components/Dialogs/add-edit-phrase-dialog.tsx
+++ b/web-app/src/components/Dialogs/add-edit-phrase-dialog.tsx
@@ -114,7 +114,7 @@ export function AddEditPhraseDialog({
           originalPhrase: originalPhraseArray,
           replacementPhrase,
           partOfSpeech,
-          expiresAt,
+          expiresAt: expiresAt ? new Date(expiresAt) : null,
           createdByUser,
         };
 


### PR DESCRIPTION
- Updated code to look for an empty string on `expries_at` and sets the value to null instead of sending the empty string to the server.