### PR TITLE
Switch from overriding global console to a local version

### DIFF
--- a/firebot-script/src/firebutt.ts
+++ b/firebot-script/src/firebutt.ts
@@ -17,7 +17,7 @@ import {
   registerFirebuttAddRemovePhraseEffectType,
   registerFirebuttUpdateResponseProbablityEffectType,
 } from './custom-effect';
-import { formattedName, scriptOutputName } from '../package.json';
+import { scriptOutputName } from '../package.json';
 import { registerFirebuttResponseProbablityReplaceVariable } from './custom-replace-variable';
 import {
   register as registerNotificationManager,
@@ -30,6 +30,7 @@ import {
 } from './phrase-manager';
 import { register as registerUsageStatistic } from './usage-statistic';
 import { getFirebotProfileDataFolderPath } from './utils/file-system';
+import { redirectConsole } from './utils/local-console';
 import { register as registerWebInterface } from './web-interface';
 
 export class Firebutt {
@@ -95,7 +96,7 @@ export class Firebutt {
 
   async register() {
     const { logger } = this._modules;
-    this.redirectConsole();
+    redirectConsole({ logger });
 
     try {
       await registerNotificationManager(this, {
@@ -151,30 +152,6 @@ export class Firebutt {
         logger.error('Failed to register Firebutt', error);
       }
     }
-  }
-
-  redirectConsole() {
-    const { logger } = this._modules;
-    const originalConsole = console;
-
-    console = {
-      ...originalConsole,
-      debug: (...args: unknown[]) => {
-        logger.info(`${formattedName}:`, ...args);
-      },
-      info: (...args: unknown[]) => {
-        logger.info(`${formattedName}:`, ...args);
-      },
-      log: (...args: unknown[]) => {
-        logger.info(`${formattedName}:`, ...args);
-      },
-      warn: (...args: unknown[]) => {
-        logger.warn(`${formattedName}:`, ...args);
-      },
-      error: (...args: unknown[]) => {
-        logger.error(`${formattedName}:`, ...args);
-      },
-    };
   }
 
   unregister() {

--- a/firebot-script/src/notification-manager.ts
+++ b/firebot-script/src/notification-manager.ts
@@ -7,6 +7,7 @@ import { Firebutt } from './firebutt';
 import { newGuid } from './guid-handler';
 import { Params } from './params';
 import { version } from '../package.json';
+import { localConsole } from './utils/local-console';
 
 enum NotificationType {
   INFO = 'info',
@@ -121,7 +122,7 @@ export async function register(
   notificationRepository = firebutt.getDataSource().getRepository(Notification);
   checkForNotificationsJob = setInterval(
     async () => {
-      console.log('Running checkForNotificationsJob');
+      localConsole.log('Running checkForNotificationsJob');
       await checkForNotifications({ firebot, modules, parameters });
     },
     1 * 60 * 1000

--- a/firebot-script/src/phrase-manager.ts
+++ b/firebot-script/src/phrase-manager.ts
@@ -6,6 +6,7 @@ import { Firebutt } from './firebutt';
 import { newGuid } from './guid-handler';
 import { Params } from './params';
 import { AddPhraseProps, UpdatePhraseProps } from './types/phrase-manager';
+import { localConsole } from './utils/local-console';
 
 let firebotModules: RunRequest<Params>['modules'] =
   null as unknown as RunRequest<Params>['modules'];
@@ -146,7 +147,7 @@ export async function register(
   });
 
   purgeExpiredPhrasesJob = setInterval(async () => {
-    console.log('Running purgeExpiredPhrasesJob');
+    localConsole.log('Running purgeExpiredPhrasesJob');
     await purgeExpiredPhrases();
   }, 1000 * 60);
 }

--- a/firebot-script/src/utils/local-console.ts
+++ b/firebot-script/src/utils/local-console.ts
@@ -1,0 +1,35 @@
+import { Console } from 'node:console';
+
+import { ScriptModules } from '@crowbartools/firebot-custom-scripts-types';
+
+import { formattedName } from '../../package.json';
+
+export let localConsole: Console;
+
+export function redirectConsole({
+  logger,
+}: Pick<ScriptModules, 'logger'>): void {
+  const originalConsole = new Console({
+    stdout: process.stdout,
+    stderr: process.stderr,
+  });
+
+  localConsole = {
+    ...originalConsole,
+    debug: (...args: unknown[]) => {
+      logger.debug(`${formattedName}:`, ...args);
+    },
+    info: (...args: unknown[]) => {
+      logger.info(`${formattedName}:`, ...args);
+    },
+    log: (...args: unknown[]) => {
+      logger.info(`${formattedName}:`, ...args);
+    },
+    warn: (...args: unknown[]) => {
+      logger.warn(`${formattedName}:`, ...args);
+    },
+    error: (...args: unknown[]) => {
+      logger.error(`${formattedName}:`, ...args);
+    },
+  };
+}


### PR DESCRIPTION
- Added `src/utils/local-console.ts` to instantiate a local console and exporting as `localConsole`
- Removing old `redirectConsole` function
- Updating usage of `console` to `localConsole`