### PR TITLE
feat: added originalMessage and user to post-processing effects variables

### DIFF
--- a/firebot-script/src/chat-client.ts
+++ b/firebot-script/src/chat-client.ts
@@ -179,6 +179,26 @@ async function execute(
               data: response,
               percentWeight: null,
             },
+            {
+              id: 'ee587f78-6e1e-4139-a220-586c9b29c2be',
+              type: 'firebot:set-output',
+              active: true,
+              outputNames: {
+                customOutput: 'originalMessage',
+              },
+              data: messageText,
+              percentWeight: null,
+            },
+            {
+              id: 'af768e7c-d0f9-4776-937c-7f157c4623e4',
+              type: 'firebot:set-output',
+              active: true,
+              outputNames: {
+                customOutput: 'user',
+              },
+              data: user,
+              percentWeight: null,
+            },
             ...postProcessingTyped.list,
           ],
         },

--- a/firebot-script/src/params.ts
+++ b/firebot-script/src/params.ts
@@ -71,7 +71,9 @@ export function getDefaultParameters(): ParametersConfig<Params> {
       type: 'effectlist',
       title: 'Post-Processing Effects',
       description:
-        'A list of effects that will be applied after phrase replacement and before sending the response. Use `$effectOutput[firebuttProcessedMessage]` to access the message after phrase replacement in your effects and use Set Output effect with output name `postProcessedMessage` to modify the final message that will be sent to chat.',
+        'A list of effects that will be applied after phrase replacement and before sending the response. Use `$effectOutput[firebuttProcessedMessage]` to access the message after phrase replacement in your effects and use Set Output effect with output name `postProcessedMessage` to modify the final message that will be sent to chat. Additionally, the following variables are available for use in your effects: \n' +
+        '- `$effectOutput[originalMessage]`: The original message before any processing.\n' +
+        '- `$effectOutput[user]`: The username of the user who sent the message.\n',
     },
   };
 }


### PR DESCRIPTION
Closes #34.

- Adds `originalMessage` and `user` values to the usable variables in Post-Processing Effects
- Updated description to include information about the two new variables