### PR TITLE
feat: add category to web app

### DIFF
--- a/firebot-script/src/phrase-manager.ts
+++ b/firebot-script/src/phrase-manager.ts
@@ -18,13 +18,16 @@ let phraseRepository: Repository<Phrase> =
 const phraseCache: Record<string, Phrase> = {};
 let purgeExpiredPhrasesJob: NodeJS.Timeout | null = null;
 
-export async function addCategory(name: string): Promise<Category> {
+export async function addCategory(
+  name: string,
+  isEnabled: boolean = true
+): Promise<Category> {
   const { id, guid } = newGuid({ type: 'category' });
   const category = categoryRepository.merge(new Category(), {
     id,
     guid,
     name,
-    isEnabled: true,
+    isEnabled,
     order: await categoryRepository.countBy({ deletedAt: IsNull() }),
   });
   await categoryRepository.save(category);
@@ -91,7 +94,10 @@ export async function addPhrase({
 
 export async function deleteCategory({ id }: { id: string }): Promise<boolean> {
   const deleted = await categoryRepository.softDelete({ id });
-  return (deleted.affected ?? 0) > 0;
+  const phrasesDeleted = await phraseRepository.softDelete({
+    category: { id },
+  });
+  return (deleted.affected ?? 0) + (phrasesDeleted.affected ?? 0) > 0;
 }
 
 export async function deletePhrase({ id }: { id: string }): Promise<boolean> {
@@ -116,18 +122,26 @@ export async function getCategory({
   return await categoryRepository.findOne({ where: { id } });
 }
 
-export async function getCategories(
-  {
-    isEnabled,
-  }: {
-    isEnabled: 'true' | 'false' | 'all';
-  } = { isEnabled: 'all' }
-): Promise<Category[]> {
-  const where = isEnabled === 'all' ? {} : { isEnabled: isEnabled === 'true' };
+export async function getCategories(): Promise<Category[]> {
   return await categoryRepository.find({
-    where,
     order: { order: 'ASC' },
   });
+}
+
+export async function getCategoriesBy(
+  key: keyof Category,
+  value: unknown,
+  options?: FindOneOptions<Category>
+): Promise<Category[]> {
+  return await categoryRepository.find({
+    where: { [key]: value },
+    order: { order: 'ASC' },
+    ...options,
+  });
+}
+
+export function getCategoryRepository(): Repository<Category> {
+  return categoryRepository;
 }
 
 export async function getOrCreateCategory(name: string): Promise<Category> {
@@ -267,13 +281,16 @@ export async function updatePhrase(
     partOfSpeech,
     expiresAt,
     createdByUser: twitchUser.displayName,
-    category: category ?? null,
+    category,
     metadata: {
       twitchAvatarUrl: twitchUser.profilePictureUrl,
       twitchUserId: twitchUser.id,
       twitchUsername: createdByUser,
     },
   });
+  if (!category) {
+    updatedPhrase.category = null;
+  }
 
   await phraseRepository.save(updatedPhrase);
   updatedPhrase.originalPhrase.forEach((originalPhrase) => {

--- a/firebot-script/src/web-interface-routes/categories.ts
+++ b/firebot-script/src/web-interface-routes/categories.ts
@@ -1,0 +1,153 @@
+import { RunRequest } from '@crowbartools/firebot-custom-scripts-types';
+import { Request, Response } from 'express';
+
+import { Firebutt } from '../firebutt';
+import { Params } from '../params';
+import {
+  addCategory,
+  deleteCategory,
+  getCategory,
+  getCategoryRepository,
+  updateCategory,
+} from '../phrase-manager';
+
+export function crudCategories(
+  _: Firebutt,
+  { modules }: Omit<RunRequest<Params>, 'trigger' | 'scriptDataDir'>
+) {
+  const { httpServer } = modules;
+
+  httpServer.registerCustomRoute(
+    'firebutt',
+    '/management/api/categories',
+    'GET',
+    async (req: Request, res: Response) => {
+      const { id } = req.query as { id?: string };
+
+      const categoriesBase = getCategoryRepository()
+        .createQueryBuilder('category')
+        .select([
+          'category.id',
+          'category.name',
+          'category.isEnabled',
+          'category.order',
+        ])
+        .where(id ? 'category.id = :id' : '', { id })
+        .orderBy('category.order', 'ASC');
+
+      const categories =
+        req.query['includeDeleted'] === 'true' || id
+          ? await categoriesBase.withDeleted().getMany()
+          : await categoriesBase.getMany();
+
+      res.setHeader('Content-Type', 'application/json');
+      res.send(
+        JSON.stringify({
+          categories,
+        })
+      );
+    }
+  );
+
+  httpServer.registerCustomRoute(
+    'firebutt',
+    '/management/api/categories',
+    'POST',
+    async (req: Request, res: Response) => {
+      const { name, isEnabled } = req.body as {
+        name: string;
+        isEnabled?: boolean;
+      };
+
+      const newCategory = await addCategory(name, isEnabled);
+
+      res.setHeader('Content-Type', 'application/json');
+      res.send(
+        JSON.stringify({
+          category: newCategory,
+        })
+      );
+    }
+  );
+
+  httpServer.registerCustomRoute(
+    'firebutt',
+    '/management/api/categories',
+    'PUT',
+    async (req: Request, res: Response) => {
+      const { id, name, isEnabled, order } = req.body as {
+        id: string;
+        name: string;
+        isEnabled: boolean;
+        order: number;
+      };
+
+      const category = await getCategory({ id });
+
+      if (category) {
+        const updatedCategory = await updateCategory(category, {
+          name,
+          isEnabled,
+          order,
+        });
+
+        res.setHeader('Content-Type', 'application/json');
+        res.send(
+          JSON.stringify({
+            category: updatedCategory,
+          })
+        );
+      } else {
+        res.status(404).send('Category not found');
+      }
+    }
+  );
+
+  httpServer.registerCustomRoute(
+    'firebutt',
+    '/management/api/categories',
+    'DELETE',
+    async (req: Request, res: Response) => {
+      const { id } = req.query as { id: string };
+
+      const deleted = await deleteCategory({ id });
+
+      res.setHeader('Content-Type', 'application/json');
+      res.send(
+        JSON.stringify({
+          deleted,
+        })
+      );
+    }
+  );
+
+  httpServer.registerCustomRoute(
+    'firebutt',
+    '/management/api/categories/reorder',
+    'PUT',
+    async (req: Request, res: Response) => {
+      const { categories } = req.body as {
+        categories: { id: string; order: number }[];
+      };
+
+      const updatedCategories = await Promise.all(
+        categories.map(async (category) => {
+          const existingCategory = await getCategory({ id: category.id });
+          if (existingCategory) {
+            return updateCategory(existingCategory, {
+              order: category.order,
+            });
+          }
+          return null;
+        })
+      );
+
+      res.setHeader('Content-Type', 'application/json');
+      res.send(
+        JSON.stringify({
+          categories: updatedCategories,
+        })
+      );
+    }
+  );
+}

--- a/firebot-script/src/web-interface-routes/phrases.ts
+++ b/firebot-script/src/web-interface-routes/phrases.ts
@@ -6,6 +6,7 @@ import { Params } from '../params';
 import {
   addPhrase,
   deletePhrase,
+  getCategory,
   getPhrase,
   getPhraseRepository,
   updatePhrase,
@@ -22,10 +23,14 @@ export function crudPhrases(
     '/management/api/phrases',
     'GET',
     async (req: Request, res: Response) => {
-      const { id } = req.query as { id?: string };
+      const { id, categoryId } = req.query as {
+        id?: string;
+        categoryId?: string;
+      };
 
       const phrasesBase = getPhraseRepository()
         .createQueryBuilder('phrase')
+        .leftJoinAndSelect('phrase.category', 'category')
         .select([
           'phrase.id',
           'phrase.originalPhrase',
@@ -35,8 +40,20 @@ export function crudPhrases(
           'phrase.createdByUser',
           'phrase.usageCount',
           'phrase.metadata',
+          'category.id',
+          'category.name',
+          'category.isEnabled',
+          'category.order',
         ])
-        .where(id ? 'phrase.id = :id' : '', { id });
+        .where(id ? 'phrase.id = :id' : '', { id })
+        .andWhere(
+          categoryId !== '00000000-0000-0000-0000-000000000000'
+            ? 'category.id = :categoryId'
+            : 'category.id IS NULL',
+          {
+            categoryId,
+          }
+        );
 
       const phrases =
         req.query['includeDeleted'] === 'true' || id
@@ -63,6 +80,7 @@ export function crudPhrases(
         partOfSpeech,
         expiresAt,
         createdByUser,
+        categoryId,
       } = req.body;
 
       const newPhrase = await addPhrase({
@@ -71,6 +89,10 @@ export function crudPhrases(
         partOfSpeech,
         expiresAt,
         createdByUser,
+        category:
+          categoryId && categoryId !== '00000000-0000-0000-0000-000000000000'
+            ? await getCategory({ id: categoryId })
+            : null,
       });
 
       res.setHeader('Content-Type', 'application/json');
@@ -94,17 +116,24 @@ export function crudPhrases(
         partOfSpeech,
         expiresAt,
         createdByUser,
+        categoryId,
       } = req.body;
 
       const phrase = await getPhrase({ id });
 
       if (phrase) {
+        const category =
+          categoryId && categoryId !== '00000000-0000-0000-0000-000000000000'
+            ? await getCategory({ id: categoryId })
+            : null;
+
         const updatedPhrase = await updatePhrase(phrase, {
           originalPhrase,
           replacementPhrase,
           partOfSpeech,
           expiresAt,
           createdByUser,
+          category,
         });
 
         res.setHeader('Content-Type', 'application/json');

--- a/firebot-script/src/web-interface.ts
+++ b/firebot-script/src/web-interface.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid';
 
 import { Firebutt } from './firebutt';
 import { Params } from './params';
+import { crudCategories } from './web-interface-routes/categories';
 import { getScriptVersion } from './web-interface-routes/get-script-version';
 import { crudPhrases } from './web-interface-routes/phrases';
 import { rqUsageStatistics } from './web-interface-routes/usage-statistics';
@@ -82,6 +83,7 @@ export function register(
   );
 
   getScriptVersion(_, { firebot, modules, parameters });
+  crudCategories(_, { firebot, modules, parameters });
   crudPhrases(_, { firebot, modules, parameters });
   rqUsageStatistics(_, { firebot, modules, parameters });
 }

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -13,6 +13,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
@@ -23,10 +26,11 @@
     "@mui/icons-material": "^6.4.5",
     "@mui/material": "^6.4.5",
     "@mui/system": "^7.0.0",
-    "@mui/x-date-pickers": "^7.28.0",
+    "@mui/x-date-pickers": "^9.6.0",
     "dayjs": "^1.11.13",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-router-dom": "^7.2.0",
     "semver": "^7.8.0"
   },
   "devDependencies": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -27,7 +27,7 @@
     "dayjs": "^1.11.13",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.2.0"
+    "semver": "^7.8.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.6",
@@ -35,6 +35,7 @@
     "@types/node": "^22.13.4",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@types/semver": "^7.7.1",
     "@typescript-eslint/eslint-plugin": "^8.24.1",
     "@typescript-eslint/parser": "^8.24.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -10,6 +10,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { Header } from './components/Header';
 import { WEB } from './constants/app';
+import { CategoryProvider } from './providers/category-provider';
 import { VersionProvider } from './providers/version-provider';
 import { Routes } from './routes';
 
@@ -25,22 +26,28 @@ export default function App() {
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <BrowserRouter basename={WEB.BASE_ROUTE}>
           <VersionProvider>
-            <GlobalStyles
-              styles={(theme) => ({
-                body: {
-                  backgroundColor: theme.palette.background.default,
-                  color: theme.palette.text.primary,
-                  margin: 0,
-                  padding: 0,
-                },
-              })}
-            />
-            <Header />
-            <Container
-              sx={{ mx: 'auto', px: '48px !important', py: '24px !important' }}
-            >
-              <Routes />
-            </Container>
+            <CategoryProvider>
+              <GlobalStyles
+                styles={(theme) => ({
+                  body: {
+                    backgroundColor: theme.palette.background.default,
+                    color: theme.palette.text.primary,
+                    margin: 0,
+                    padding: 0,
+                  },
+                })}
+              />
+              <Header />
+              <Container
+                sx={{
+                  mx: 'auto',
+                  px: '48px !important',
+                  py: '24px !important',
+                }}
+              >
+                <Routes />
+              </Container>
+            </CategoryProvider>
           </VersionProvider>
         </BrowserRouter>
       </LocalizationProvider>

--- a/web-app/src/components/CategorySwitcher/category-switcher.tsx
+++ b/web-app/src/components/CategorySwitcher/category-switcher.tsx
@@ -1,0 +1,138 @@
+import {
+  Add as AddIcon,
+  Edit as EditIcon,
+  Reorder as ReorderIcon,
+} from '@mui/icons-material';
+import {
+  Box,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Tooltip,
+} from '@mui/material';
+import { useCallback, useState } from 'react';
+import semver from 'semver';
+
+import { useCategory } from '../../hooks/use-category';
+import { useVersion } from '../../hooks/use-version';
+import { AddEditCategoryDialog, ReorderCategoryDialog } from '../Dialogs';
+
+export function CategorySwitcher() {
+  const {
+    categories,
+    selectedCategory,
+    setSelectedCategory,
+    refreshCategories,
+  } = useCategory();
+  const { scriptVersion } = useVersion();
+
+  const [isAddEditItemOpen, setIsAddEditItemOpen] = useState(false);
+  const [isReorderOpen, setIsReorderOpen] = useState(false);
+  const [modalMode, setModalMode] = useState<'add' | 'edit'>('add');
+
+  const handleSelectedCategoryChange = useCallback(
+    (categoryId: string) => {
+      setSelectedCategory(categoryId);
+    },
+    [setSelectedCategory]
+  );
+
+  const handleOpenAddItem = useCallback(() => {
+    setModalMode('add');
+    setIsAddEditItemOpen(true);
+  }, [setIsAddEditItemOpen]);
+
+  const handleOpenEditItem = useCallback(() => {
+    setModalMode('edit');
+    setIsAddEditItemOpen(true);
+  }, [setIsAddEditItemOpen]);
+
+  const handleCloseAddEditItem = useCallback(() => {
+    setIsAddEditItemOpen(false);
+  }, [setIsAddEditItemOpen]);
+
+  const handleOpenReorder = useCallback(() => {
+    setIsReorderOpen(true);
+  }, [setIsReorderOpen]);
+
+  const handleCloseReorder = useCallback(() => {
+    setIsReorderOpen(false);
+  }, [setIsReorderOpen]);
+
+  const handleRefresh = useCallback(() => {
+    refreshCategories();
+  }, [refreshCategories]);
+
+  switch (true) {
+    case semver.satisfies(scriptVersion, '>=2.0.0'):
+      return (
+        <>
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              flexDirection: 'row',
+              mb: 2,
+              mt: 1,
+            }}
+          >
+            <InputLabel id='category-switcher-label' sx={{ mr: 2 }}>
+              Phrase Set:
+            </InputLabel>
+            <Select
+              labelId='category-switcher-label'
+              key='category-switcher'
+              value={selectedCategory}
+              variant='standard'
+              onChange={(e) => handleSelectedCategoryChange(e.target.value)}
+            >
+              {categories.map((category) => (
+                <MenuItem key={category.id} value={category.id}>
+                  {category.name} {!category.isEnabled && '(Disabled)'}
+                </MenuItem>
+              ))}
+            </Select>
+            <Tooltip title='Add Phrase Set' placement='top'>
+              <IconButton onClick={handleOpenAddItem}>
+                <AddIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title='Edit Phrase Set' placement='top'>
+              <IconButton
+                onClick={handleOpenEditItem}
+                disabled={
+                  selectedCategory === '00000000-0000-0000-0000-000000000000'
+                }
+              >
+                <EditIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title='Reorder Phrase Sets' placement='top'>
+              <IconButton onClick={handleOpenReorder}>
+                <ReorderIcon />
+              </IconButton>
+            </Tooltip>
+          </Box>
+          <AddEditCategoryDialog
+            open={isAddEditItemOpen}
+            handleClose={handleCloseAddEditItem}
+            mode={modalMode}
+            formData={
+              modalMode === 'edit'
+                ? categories.find((c) => c.id === selectedCategory)
+                : undefined
+            }
+            handleRefresh={handleRefresh}
+          />
+          <ReorderCategoryDialog
+            open={isReorderOpen}
+            handleClose={handleCloseReorder}
+            handleRefresh={handleRefresh}
+          />
+        </>
+      );
+    default:
+      return <></>;
+  }
+}

--- a/web-app/src/components/CategorySwitcher/index.ts
+++ b/web-app/src/components/CategorySwitcher/index.ts
@@ -1,0 +1,1 @@
+export { CategorySwitcher } from './category-switcher';

--- a/web-app/src/components/Dialogs/add-edit-category-dialog.tsx
+++ b/web-app/src/components/Dialogs/add-edit-category-dialog.tsx
@@ -1,0 +1,150 @@
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  FormControlLabel,
+  TextField,
+} from '@mui/material';
+import { useCallback, useMemo } from 'react';
+
+import { WEB } from '../../constants/app';
+import { DialogComponentProps } from '../EnhancedTable';
+
+interface AddEditCategoryDialogProps extends DialogComponentProps {
+  formData?: CategoryData;
+  mode: 'add' | 'edit';
+}
+
+export function AddEditCategoryDialog({
+  formData: categoryData,
+  handleClose,
+  handleRefresh,
+  mode,
+  open,
+}: AddEditCategoryDialogProps) {
+  const dialogTitle = useMemo(() => {
+    return mode === 'add' ? 'Add Category' : 'Edit Category';
+  }, [mode]);
+
+  const onSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const formData = new FormData(event.currentTarget);
+      const { id, name, isEnabled, order } = Object.fromEntries(
+        formData
+      ) as unknown as CategoryData;
+
+      if (mode === 'add') {
+        const newCategoryData = {
+          name,
+          isEnabled,
+          order: Number(order),
+        };
+
+        const response = await fetch(
+          `${WEB.BASE_ORIGIN}${WEB.API_ROUTE}/categories`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(newCategoryData),
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error('Failed to add category');
+        }
+        const data = await response.json();
+        if (data.error) {
+          throw new Error(data.error);
+        }
+      }
+
+      if (mode === 'edit') {
+        const updatedCategoryData = {
+          id,
+          name,
+          isEnabled,
+          order: Number(order),
+        };
+
+        const response = await fetch(
+          `${WEB.BASE_ORIGIN}${WEB.API_ROUTE}/categories/?id=${id}`,
+          {
+            method: 'PUT',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(updatedCategoryData),
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error('Failed to update category');
+        }
+        const data = await response.json();
+        if (data.error) {
+          throw new Error(data.error);
+        }
+      }
+
+      handleClose();
+      handleRefresh();
+    },
+    [handleClose, handleRefresh, mode]
+  );
+
+  return (
+    <Dialog
+      open={open as boolean}
+      slotProps={{
+        paper: {
+          component: 'form',
+          onSubmit,
+        },
+      }}
+    >
+      <DialogTitle>{dialogTitle}</DialogTitle>
+      <DialogContent>
+        <DialogContentText></DialogContentText>
+        <TextField
+          id='id'
+          name='id'
+          type='hidden'
+          value={categoryData?.id}
+          variant='standard'
+        />
+        <TextField
+          autoFocus
+          defaultValue={categoryData?.name}
+          fullWidth
+          id='name'
+          label='Name'
+          margin='dense'
+          name='name'
+          type='text'
+          variant='standard'
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              id='isEnabled'
+              name='isEnabled'
+              defaultChecked={categoryData?.isEnabled ?? true}
+            />
+          }
+          label='Is Enabled'
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button type='submit'>Save</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/web-app/src/components/Dialogs/add-edit-phrase-dialog.tsx
+++ b/web-app/src/components/Dialogs/add-edit-phrase-dialog.tsx
@@ -17,9 +17,12 @@ import {
 import { DateTimePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { useCallback, useMemo } from 'react';
+import semver from 'semver';
 
 import { WEB } from '../../constants/app';
 import { partOfSpeech } from '../../constants/pos';
+import { useCategory } from '../../hooks/use-category';
+import { useVersion } from '../../hooks/use-version';
 import { DialogComponentProps } from '../EnhancedTable';
 
 interface AddEditPhraseDialogProps extends DialogComponentProps {
@@ -39,6 +42,9 @@ export function AddEditPhraseDialog({
   mode,
   open,
 }: AddEditPhraseDialogProps) {
+  const { categories, selectedCategory } = useCategory();
+  const { scriptVersion } = useVersion();
+
   const dialogTitle = useMemo(() => {
     return mode === 'add' ? 'Add Phrase' : 'Edit Phrase';
   }, [mode]);
@@ -48,6 +54,7 @@ export function AddEditPhraseDialog({
       event.preventDefault();
       const formData = new FormData(event.currentTarget);
       const {
+        categoryId,
         createdByUser,
         expiresAt,
         expiresInDays,
@@ -80,6 +87,10 @@ export function AddEditPhraseDialog({
               ? addDays(new Date(), Number(expiresInDays))
               : null,
           createdByUser,
+          categoryId:
+            categoryId !== '00000000-0000-0000-0000-000000000000'
+              ? categoryId
+              : null,
         };
 
         const response = await fetch(
@@ -116,6 +127,10 @@ export function AddEditPhraseDialog({
           partOfSpeech,
           expiresAt: expiresAt ? new Date(expiresAt) : null,
           createdByUser,
+          categoryId:
+            categoryId !== '00000000-0000-0000-0000-000000000000'
+              ? categoryId
+              : null,
         };
 
         const response = await fetch(
@@ -228,6 +243,25 @@ export function AddEditPhraseDialog({
             )}
           </Select>
         </FormControl>
+        {semver.satisfies(scriptVersion, '>=2.0.0') && (
+          <FormControl fullWidth margin='dense' variant='standard'>
+            <InputLabel id='categoryLabel'>Category</InputLabel>
+            <Select
+              defaultValue={selectedCategory}
+              inputProps={{ id: 'categoryId', name: 'categoryId' }}
+              label='Category'
+              labelId='categoryLabel'
+              margin='dense'
+              variant='standard'
+            >
+              {categories.map((category) => (
+                <MenuItem key={category.id} value={category.id}>
+                  {category.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
         {mode === 'add' ? (
           <TextField
             fullWidth

--- a/web-app/src/components/Dialogs/index.ts
+++ b/web-app/src/components/Dialogs/index.ts
@@ -1,2 +1,4 @@
+export { AddEditCategoryDialog } from './add-edit-category-dialog';
 export { AddEditPhraseDialog } from './add-edit-phrase-dialog';
 export { DeletePhraseDialog } from './delete-phrase-dialog';
+export { ReorderCategoryDialog } from './reorder-category-dialog';

--- a/web-app/src/components/Dialogs/reorder-category-dialog.tsx
+++ b/web-app/src/components/Dialogs/reorder-category-dialog.tsx
@@ -1,0 +1,94 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+} from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+
+import { useCategory } from '../../hooks/use-category';
+import { DialogComponentProps } from '../EnhancedTable';
+import {
+  Item,
+  ReorderableMuiList,
+  SortableListItem,
+} from '../ReorderableMuiList';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface ReorderCategoryDialogProps extends DialogComponentProps {}
+
+export function ReorderCategoryDialog({
+  handleClose,
+  handleRefresh,
+  open,
+}: ReorderCategoryDialogProps) {
+  const { categories: categoryData, updateCategoryOrders } = useCategory();
+  const [items, setItems] = useState<Item[]>([]);
+
+  useEffect(() => {
+    setItems(
+      categoryData
+        .filter(({ id }) => id !== '00000000-0000-0000-0000-000000000000')
+        .map(
+          (category) =>
+            ({
+              id: category.id,
+              label: category.name,
+            }) as Item
+        )
+    );
+  }, [categoryData]);
+
+  const onSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      await updateCategoryOrders(
+        items
+          .filter((item) => item.id !== '00000000-0000-0000-0000-000000000000')
+          .map((item, index) => ({
+            ...categoryData.find((category) => category.id === item.id)!,
+            order: index,
+          }))
+      );
+      await handleRefresh();
+      handleClose();
+    },
+    [items, categoryData, handleRefresh, handleClose, updateCategoryOrders]
+  );
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        fullWidth
+        maxWidth='sm'
+        slotProps={{
+          paper: {
+            component: 'form',
+            onSubmit,
+          },
+        }}
+      >
+        <DialogTitle>Reorder Categories</DialogTitle>
+        <DialogContent>
+          <SortableListItem
+            item={{
+              id: '00000000-0000-0000-0000-000000000000',
+              label: 'General Phrases',
+            }}
+            disabled
+          />
+          <Divider sx={{ my: 1 }} />
+          <ReorderableMuiList items={items} setItems={setItems} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button type='submit'>Save</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/web-app/src/components/ReorderableMuiList/index.ts
+++ b/web-app/src/components/ReorderableMuiList/index.ts
@@ -1,0 +1,2 @@
+export { ReorderableMuiList } from './reorderable-mui-list';
+export { SortableListItem, type Item } from './sortable-list-item';

--- a/web-app/src/components/ReorderableMuiList/reorderable-mui-list.tsx
+++ b/web-app/src/components/ReorderableMuiList/reorderable-mui-list.tsx
@@ -1,0 +1,71 @@
+import {
+  closestCenter,
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { List } from '@mui/material';
+
+import { Item, SortableListItem } from './sortable-list-item';
+
+interface ReorderableMuiListProps {
+  items: Item[];
+  setItems: (orderedItems: Item[]) => void;
+}
+
+export function ReorderableMuiList({
+  items,
+  setItems,
+}: ReorderableMuiListProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    const oldIndex = items.findIndex((item) => item.id === active.id);
+    const newIndex = items.findIndex((item) => item.id === over.id);
+
+    if (oldIndex === -1 || newIndex === -1) {
+      return;
+    }
+
+    setItems(arrayMove(items, oldIndex, newIndex));
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={items.map((item) => item.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <List>
+          {items.map((item) => (
+            <SortableListItem key={item.id} item={item} />
+          ))}
+        </List>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/web-app/src/components/ReorderableMuiList/sortable-list-item.tsx
+++ b/web-app/src/components/ReorderableMuiList/sortable-list-item.tsx
@@ -1,0 +1,55 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import { IconButton, ListItem, ListItemText, Paper } from '@mui/material';
+
+export interface Item {
+  id: string;
+  label: string;
+}
+
+interface SortableListItemProps {
+  item: Item;
+  disabled?: boolean;
+}
+
+export function SortableListItem({
+  item,
+  disabled = false,
+}: SortableListItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  return (
+    <ListItem
+      ref={setNodeRef}
+      component={Paper}
+      sx={{
+        mb: 1,
+        opacity: isDragging ? 0.6 : 1,
+        transform: CSS.Transform.toString(transform),
+        transition,
+        cursor: disabled ? 'not-allowed' : 'default',
+      }}
+      secondaryAction={
+        <IconButton
+          edge='end'
+          {...attributes}
+          {...listeners}
+          sx={{ cursor: disabled ? 'not-allowed' : 'grab' }}
+          disabled={disabled}
+        >
+          {!disabled ? <DragIndicatorIcon /> : null}
+        </IconButton>
+      }
+    >
+      <ListItemText primary={item.label} />
+    </ListItem>
+  );
+}

--- a/web-app/src/hooks/use-category.ts
+++ b/web-app/src/hooks/use-category.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { CategoryContext } from '../providers/context/category-context';
+
+export function useCategory() {
+  return useContext(CategoryContext);
+}

--- a/web-app/src/pages/phrase-management.tsx
+++ b/web-app/src/pages/phrase-management.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { CategorySwitcher } from '../components/CategorySwitcher';
 import { PartOfSpeech, TwitchUser } from '../components/Columns';
 import { AddEditPhraseDialog, DeletePhraseDialog } from '../components/Dialogs';
 import { EnhancedColumn, EnhancedTable } from '../components/EnhancedTable';
 import { WEB } from '../constants/app';
+import { useCategory } from '../hooks/use-category';
 
 export default function PhraseManagement() {
+  const { selectedCategory: categoryId } = useCategory();
   const [rows, setRows] = useState<PhraseData[]>([]);
-  const [refresh, setRefresh] = useState(true);
 
   const columns: EnhancedColumn<PhraseData>[] = [
     {
@@ -45,32 +47,31 @@ export default function PhraseManagement() {
     },
   ];
 
-  const handleRefresh = useCallback(() => {
-    setRefresh(true);
-  }, [setRefresh]);
+  const handleRefresh = useCallback(async () => {
+    const apiUrl = `${WEB.BASE_ORIGIN}${WEB.API_ROUTE}/phrases?categoryId=${categoryId}`;
+    const response = await fetch(apiUrl);
+    const data = (await response.json()).phrases as PhraseData[];
+    setRows(data);
+  }, [categoryId]);
 
   useEffect(() => {
-    if (!refresh) return;
-    (async () => {
-      const apiUrl = `${WEB.BASE_ORIGIN}${WEB.API_ROUTE}/phrases`;
-      const response = await fetch(apiUrl);
-      const data = (await response.json()).phrases as PhraseData[];
-      setRows(data);
-    })();
-    setRefresh(false);
-  }, [refresh, setRows]);
+    handleRefresh();
+  }, [categoryId, handleRefresh]);
 
   return (
-    <EnhancedTable<PhraseData>
-      addItemComponent={AddEditPhraseDialog}
-      columns={columns}
-      defaultColumnForOrderBy='originalPhrase'
-      deleteItemComponent={DeletePhraseDialog}
-      editItemComponent={AddEditPhraseDialog}
-      entityNameForTooltips='Phrase'
-      handleRefresh={handleRefresh}
-      rows={rows}
-      tableTitle='Phrase Management'
-    />
+    <>
+      <CategorySwitcher />
+      <EnhancedTable<PhraseData>
+        addItemComponent={AddEditPhraseDialog}
+        columns={columns}
+        defaultColumnForOrderBy='originalPhrase'
+        deleteItemComponent={DeletePhraseDialog}
+        editItemComponent={AddEditPhraseDialog}
+        entityNameForTooltips='Phrase'
+        handleRefresh={handleRefresh}
+        rows={rows}
+        tableTitle='Phrase Management'
+      />
+    </>
   );
 }

--- a/web-app/src/providers/category-provider.tsx
+++ b/web-app/src/providers/category-provider.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from 'react';
+import semver from 'semver';
+
+import { CategoryContext } from './context/category-context';
+import { WEB } from '../constants/app';
+import { useValue } from '../hooks/use-value';
+import { useVersion } from '../hooks/use-version';
+
+interface CategoryProviderProps {
+  children: React.ReactNode;
+}
+
+const defaultCategory: CategoryData = {
+  id: '00000000-0000-0000-0000-000000000000',
+  name: 'General Phrases',
+  isEnabled: true,
+  order: 0,
+  insertedAt: new Date(),
+  updatedAt: new Date(),
+};
+
+export function CategoryProvider({ children }: CategoryProviderProps) {
+  const [categories, setCategories] = useState<CategoryData[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<string>(
+    '00000000-0000-0000-0000-000000000000'
+  );
+  const { scriptVersion } = useVersion();
+
+  const refreshCategories = useCallback(async () => {
+    if (semver.satisfies(scriptVersion, '>=2.0.0')) {
+      const apiUrl = `${WEB.BASE_ORIGIN}${WEB.API_ROUTE}/categories`;
+      const { categories } = (await (await fetch(apiUrl)).json()) as {
+        categories: CategoryData[];
+      };
+      setCategories(categories);
+    }
+  }, [setCategories, scriptVersion]);
+
+  const updateCategoryOrders = useCallback(
+    async (orderedCategories: CategoryData[]) => {
+      if (semver.satisfies(scriptVersion, '>=2.0.0')) {
+        const apiUrl = `${WEB.BASE_ORIGIN}${WEB.API_ROUTE}/categories/reorder`;
+        const { categories } = (await (
+          await fetch(apiUrl, {
+            method: 'PUT',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ categories: orderedCategories }),
+          })
+        ).json()) as { categories: CategoryData[] };
+        setCategories(categories);
+      }
+    },
+    [setCategories, scriptVersion]
+  );
+
+  useEffect(() => {
+    (async () => {
+      await refreshCategories();
+    })();
+  }, [refreshCategories]);
+
+  const values = useValue({
+    categories: [defaultCategory, ...(categories ?? [])],
+    refreshCategories,
+    selectedCategory,
+    setSelectedCategory,
+    updateCategoryOrders,
+  });
+
+  return (
+    <CategoryContext.Provider value={{ ...values }}>
+      {children}
+    </CategoryContext.Provider>
+  );
+}

--- a/web-app/src/providers/context/category-context.ts
+++ b/web-app/src/providers/context/category-context.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { createContext } from 'react';
+
+export const CategoryContext = createContext<CategoryProviderValue>({
+  categories: [],
+  selectedCategory: '',
+  setSelectedCategory: (_: string) => {},
+  refreshCategories: (): Promise<void> => Promise.resolve(),
+  updateCategoryOrders: (_: CategoryData[]): Promise<void> => Promise.resolve(),
+});

--- a/web-app/src/providers/context/version-context.ts
+++ b/web-app/src/providers/context/version-context.ts
@@ -1,3 +1,6 @@
 import { createContext } from 'react';
 
-export const VersionContext = createContext<Partial<Version>>({});
+export const VersionContext = createContext<Version>({
+  scriptVersion: '0.0.0',
+  webAppVersion: '0.0.0',
+});

--- a/web-app/types/category.d.ts
+++ b/web-app/types/category.d.ts
@@ -1,0 +1,16 @@
+interface CategoryData {
+  id: string;
+  name: string;
+  isEnabled: boolean;
+  order: number;
+  insertedAt: Date;
+  updatedAt: Date;
+}
+
+interface CategoryProviderValue {
+  categories: CategoryData[];
+  refreshCategories: () => Promise<void>;
+  selectedCategory: string;
+  setSelectedCategory: (id: string) => void;
+  updateCategoryOrders: (orderedCategories: CategoryData[]) => Promise<void>;
+}

--- a/web-app/types/phrase-management.d.ts
+++ b/web-app/types/phrase-management.d.ts
@@ -6,6 +6,7 @@ interface PhraseData {
   expiresAt: Date | null;
   usageCount: number;
   createdByUser: string;
+  categoryId: string | null;
   metadata: {
     twitchAvatarUrl?: string;
     twitchUserId?: string;

--- a/web-app/yarn.lock
+++ b/web-app/yarn.lock
@@ -140,12 +140,17 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.25.7", "@babel/runtime@^7.26.10":
+"@babel/runtime@^7.26.10":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.0.tgz#fbee7cf97c709518ecc1f590984481d5460d4762"
   integrity sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==
   dependencies:
     regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.29.2", "@babel/runtime@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
 "@babel/template@^7.26.9":
   version "7.26.9"
@@ -176,6 +181,47 @@
   dependencies:
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
+
+"@base-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@base-ui/utils/-/utils-0.2.9.tgz#f6fe1704722a072721704f487a48754dbfe8f96b"
+  integrity sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==
+  dependencies:
+    "@babel/runtime" "^7.29.2"
+    "@floating-ui/utils" "^0.2.11"
+    reselect "^5.1.1"
+    use-sync-external-store "^1.6.0"
+
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz#1f9382b90d835cd5c65d92824fa9dafb78c4c3e8"
+  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
 
 "@emotion/babel-plugin@^11.13.5":
   version "11.13.5"
@@ -495,6 +541,11 @@
     "@eslint/core" "^0.11.0"
     levn "^0.4.1"
 
+"@floating-ui/utils@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
+  integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
+
 "@fortawesome/fontawesome-common-types@6.7.2":
   version "6.7.2"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz#7123d74b0c1e726794aed1184795dbce12186470"
@@ -728,17 +779,12 @@
   dependencies:
     "@babel/runtime" "^7.26.10"
 
-"@mui/utils@^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta", "@mui/utils@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-7.0.0.tgz#4e3411de9ac8f2892fdd97852260eb724731c0cd"
-  integrity sha512-oCRO9o08klpO13lZvPUt+ocmkyMlnAk76Eo8IIel6dcCBQQ0sTI5QNiSMzGC+JvusfPMGdvgIOVtHeyhRijJfQ==
+"@mui/types@^9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-9.1.1.tgz#38b6d59b85943bc2a9737a1afc2d06f7f82939ae"
+  integrity sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==
   dependencies:
-    "@babel/runtime" "^7.26.10"
-    "@mui/types" "^7.4.0"
-    "@types/prop-types" "^15.7.14"
-    clsx "^2.1.1"
-    prop-types "^15.8.1"
-    react-is "^19.0.0"
+    "@babel/runtime" "^7.29.2"
 
 "@mui/utils@^6.4.3":
   version "6.4.3"
@@ -752,26 +798,54 @@
     prop-types "^15.8.1"
     react-is "^19.0.0"
 
-"@mui/x-date-pickers@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-7.28.0.tgz#1daa089722b7b3b7458ad9af1ef39ae5ec9a9918"
-  integrity sha512-m1bfkZLOw3cMogeh6q92SjykVmLzfptnz3ZTgAlFKV7UBnVFuGUITvmwbgTZ1Mz3FmLVnGUQYUpZWw0ZnoghNA==
+"@mui/utils@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-7.0.0.tgz#4e3411de9ac8f2892fdd97852260eb724731c0cd"
+  integrity sha512-oCRO9o08klpO13lZvPUt+ocmkyMlnAk76Eo8IIel6dcCBQQ0sTI5QNiSMzGC+JvusfPMGdvgIOVtHeyhRijJfQ==
   dependencies:
-    "@babel/runtime" "^7.25.7"
-    "@mui/utils" "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
-    "@mui/x-internals" "7.28.0"
-    "@types/react-transition-group" "^4.4.11"
+    "@babel/runtime" "^7.26.10"
+    "@mui/types" "^7.4.0"
+    "@types/prop-types" "^15.7.14"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-is "^19.0.0"
+
+"@mui/utils@^9.0.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-9.1.1.tgz#94dbb62dbaadad0d890ca0501838ce578d17da04"
+  integrity sha512-qSNfnkzZMptaaWFFklpDf4NPJztgwsMDVfM/sSDt+wq4ssYSBhLYwwjuB6eS/+p2IUYbeRzHluzXbw0Zn7aI4A==
+  dependencies:
+    "@babel/runtime" "^7.29.2"
+    "@mui/types" "^9.1.1"
+    "@types/prop-types" "^15.7.15"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-is "^19.2.6"
+
+"@mui/x-date-pickers@^9.6.0":
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-9.6.0.tgz#d27afa81e03f12b8c9938b5d2996a34e9862cad9"
+  integrity sha512-Cdk0qkdfxjQtDAnrQdrkCCGyXifjmqzzoDnnoPPxLz5915BWW33cAG9RcZFUAupRaUuh3i6QE8C5oUA9Mrx+1A==
+  dependencies:
+    "@babel/runtime" "^7.29.7"
+    "@mui/utils" "^9.0.1"
+    "@mui/x-internals" "^9.6.0"
+    "@types/react-transition-group" "^4.4.12"
     clsx "^2.1.1"
     prop-types "^15.8.1"
     react-transition-group "^4.4.5"
 
-"@mui/x-internals@7.28.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-7.28.0.tgz#b0a04f4c0f53f2f91d13a46f357f731b77c832c5"
-  integrity sha512-p4GEp/09bLDumktdIMiw+OF4p+pJOOjTG0VUvzNxjbHB9GxbBKoMcHrmyrURqoBnQpWIeFnN/QAoLMFSpfwQbw==
+"@mui/x-internals@^9.6.0":
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-9.6.0.tgz#5f9e65adf0d45146437a2f1e32530d8f27df4763"
+  integrity sha512-lBh+4P2CRyspoFbBwCemTFIYmAAX8esznDsYYDGgV0+Id9z7Xi5pRZUAFY33XodYgTnMPiN4TJyfd8bfJbPNzg==
   dependencies:
-    "@babel/runtime" "^7.25.7"
-    "@mui/utils" "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
+    "@babel/runtime" "^7.29.7"
+    "@base-ui/utils" "^0.2.9"
+    "@mui/utils" "^9.0.1"
+    core-js-pure "^3.49.0"
+    reselect "^5.2.0"
+    use-sync-external-store "^1.6.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1076,12 +1150,17 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.14.tgz#1433419d73b2a7ebfc6918dcefd2ec0d5cd698f2"
   integrity sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==
 
+"@types/prop-types@^15.7.15":
+  version "15.7.15"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.15.tgz#e6e5a86d602beaca71ce5163fadf5f95d70931c7"
+  integrity sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==
+
 "@types/react-dom@^19.0.4":
   version "19.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.0.4.tgz#bedba97f9346bd4c0fe5d39e689713804ec9ac89"
   integrity sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==
 
-"@types/react-transition-group@^4.4.11", "@types/react-transition-group@^4.4.12":
+"@types/react-transition-group@^4.4.12":
   version "4.4.12"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
@@ -1092,6 +1171,11 @@
   integrity sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==
   dependencies:
     csstype "^3.0.2"
+
+"@types/semver@^7.7.1":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
+  integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
 
 "@typescript-eslint/eslint-plugin@8.24.1", "@typescript-eslint/eslint-plugin@^8.24.1":
   version "8.24.1"
@@ -1517,6 +1601,11 @@ cookie@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
   integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
+
+core-js-pure@^3.49.0:
+  version "3.49.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.49.0.tgz#ff8436b7251a3832f5fdbbe3e10f7f2e58e51fb1"
+  integrity sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==
 
 cosmiconfig@^7.0.0:
   version "7.1.0"
@@ -3096,6 +3185,11 @@ react-is@^19.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.0.0.tgz#d6669fd389ff022a9684f708cf6fa4962d1fea7a"
   integrity sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==
 
+react-is@^19.2.6:
+  version "19.2.7"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.7.tgz#57668ee86a78574a542b0a539455212b2c086df2"
+  integrity sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==
+
 react-refresh@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
@@ -3168,6 +3262,11 @@ require-relative@^0.8.7:
   version "0.8.7"
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
   integrity sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg==
+
+reselect@^5.1.1, reselect@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.2.0.tgz#f380ef7664332d26ea06c1cba04bdbbdcaa955f1"
+  integrity sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -3277,6 +3376,11 @@ semver@^7.3.6, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
+semver@^7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.0.tgz#ed0661039fcbcda2ce71f01fa6adbefaa77040df"
+  integrity sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==
 
 set-cookie-parser@^2.6.0:
   version "2.7.1"
@@ -3530,7 +3634,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.3, tslib@^2.6.2:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.6.2:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -3640,6 +3744,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 vite-plugin-svgr@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
Closes #42.
- Created new category context, provider, and hook.
- Updated version context to have default values
- Updated some getters/setters from `firebot-script` (see #41)
- Updated web app with `CategorySwitcher`, with add/edit and reorder dialogs, and `ReorderableMuiList` components.